### PR TITLE
Add missing column hidecalendar to organizer table

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -21,6 +21,7 @@
         <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="relativedeadline" NEXT="queue"/>
         <FIELD NAME="queue" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="grade" NEXT="visibility" COMMENT="Flag to trigger waiting queues for slot appointments."/>
         <FIELD NAME="visibility" TYPE="int" LENGTH="4" NOTNULL="false" DEFAULT="0" SEQUENCE="false" PREVIOUS="queue"/>
+        <FIELD NAME="hidecalendar" TYPE="int" LENGTH="4" NOTNULL="false" DEFAULT="0" SEQUENCE="false" PREVIOUS="visibility"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>


### PR DESCRIPTION
Commit be33931 made a bunch of schema changes and specified an upgrade path in `upgrade.php`. Unfortunatelly, `install.xml` haven't got all of the new columns, column `hidecalendar` was missing.

This problem could have slipped through the cracks if a moodle installation already had the `organizer` plugin installed, but it lead to database query errors after a fresh installation.
